### PR TITLE
Port covimerage to coveragepy 7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
     install_requires=[
         'attrs>=16.1.0',
         'click<7.1',
-        'coverage<5.0a6',
+        'coverage',
     ],
     extras_require={
         'testing': DEPS_TESTING,


### PR DESCRIPTION
Tests are pretty broken, because of the changes made to parse_count_and_times().

Those changes were necessary, because vim aligns columns differently depending on what data preceeds the line.
I could work out how to parse the count, self and total time, but source lines are difficult because preceeding whitespace could be source line indentation or profile column padding.
The hacky workaround is to treat all whitespace preceeding the line as padding and just use lstrip() everywhere.
Ideally, we'd have something more structured to parse.